### PR TITLE
feat:k8sでWordPressの環境をローカル構築

### DIFF
--- a/07/aqua.yaml
+++ b/07/aqua.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.384.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: 01mf02/jaq@v2.3.0
+- name: kubernetes-sigs/kind@v0.29.0
+- name: kubernetes-sigs/kustomize@kustomize/v5.7.0

--- a/07/cluster.yaml
+++ b/07/cluster.yaml
@@ -1,0 +1,10 @@
+# HA 構成の Cluster を作成する
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/07/k8s/wordpress.yaml
+++ b/07/k8s/wordpress.yaml
@@ -1,0 +1,166 @@
+# ---------- Namespace ----------
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wp
+
+# ---------- Secret ----------
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wp-db-secret
+  namespace: wp
+type: Opaque
+data:
+  # echo -n password | base64
+  mariadb-root-pass: cGFzc3dvcmQ=
+  mariadb-user: d29yZHByZXNzX3VzZXI=
+  mariadb-pass: cGFzc3dvcmQ=
+
+# ---------- PersistentVolumeClaims ----------
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-db-pvc
+  namespace: wp
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+  namespace: wp
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 1Gi
+
+# ---------- MariaDB Deployment & Service ----------
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+  namespace: wp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+        - name: mariadb
+          image: mirror.gcr.io/mariadb:11.8.1-ubi9-rc
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wp-db-secret
+                  key: mariadb-root-pass
+            - name: MYSQL_DATABASE
+              value: wordpress
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wp-db-secret
+                  key: mariadb-user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wp-db-secret
+                  key: mariadb-pass
+          volumeMounts:
+            - name: db-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: db-storage
+          persistentVolumeClaim:
+            claimName: wp-db-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace: wp
+spec:
+  selector:
+    app: mariadb
+  ports:
+    - port: 3306
+      targetPort: 3306
+  type: ClusterIP
+
+# ---------- WordPress Deployment & Service ----------
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+  namespace: wp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+        - name: wordpress
+          image: mirror.gcr.io/wordpress:6.8.1-php8.1-apache
+          ports:
+            - containerPort: 80
+          env:
+            - name: WORDPRESS_DB_HOST
+              value: mariadb.wp.svc.cluster.local:3306
+            - name: WORDPRESS_DB_NAME
+              value: wordpress
+            - name: WORDPRESS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wp-db-secret
+                  key: mariadb-user
+            - name: WORDPRESS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wp-db-secret
+                  key: mariadb-pass
+          volumeMounts:
+            - name: wp-storage
+              mountPath: /var/www/html
+      volumes:
+        - name: wp-storage
+          persistentVolumeClaim:
+            claimName: wp-data-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  namespace: wp
+spec:
+  selector:
+    app: wordpress
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30080
+  type: NodePort

--- a/07/kustomization.yaml
+++ b/07/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - k8s/wordpress.yaml
+namespace: wp   # stack 内と同じなら省いても可


### PR DESCRIPTION
## k8sの学習のため
## 07のフォルダを作成し、k8sでローカルでWordPressの環境を構築した
## 動作確認の手順
- cluster.yaml を作成し、そこにHA 構成を記載
- aqua i -l  でシンボリックリンクを作成し、kindを反映
- kind version  kindの導入確認
- kubectl get nodesでnode 一覧を表示
- kind create cluster --config cluster.yaml  でシングルノード・クラスタを立てた
- k8s/wordpress.yaml　を作成し、WordPress スタックを構成
- ビルドするためにkustomization.yamlを作成
- aqua g -i   でバイナリを取得し、kustomizeを反映
- kustomize build . |kubectl apply -f -するが失敗
- うまくいかなかったので、echo '- name: kubernetes-sigs/kustomize@kustomize/v5.7.0' >> aqua.yaml
- aqua g -i   でバイナリを再取得
- kustomize build . |kubectl apply -f -でビルドしてクラスタに適用
- kubectl port-forward service/wordpress 8080:8080するがデフォルトで default 名前空間を探すらしく、デプロイしたリソースは wp 名前空間配下だから見つからず 404 となった
- そのためkubectl -n wp port-forward svc/wordpress 8080:80で開通
